### PR TITLE
iperf_task: fix warnings

### DIFF
--- a/plus/Common/Utilities/iperf_task_v3_0f.c
+++ b/plus/Common/Utilities/iperf_task_v3_0f.c
@@ -971,7 +971,7 @@ int sscanf64( char * pcString,
 	char * pcSource = pcString;
 	uint64_t ullAmount = 0U;
 
-	if( isdigit( *pcSource ) )
+	if( isdigit( ( int ) *pcSource ) )
 	{
 		retValue = 1;
 
@@ -980,7 +980,7 @@ int sscanf64( char * pcString,
 			ullAmount = 10U * ullAmount;
 			ullAmount += ( uint64_t ) ( *pcSource - '0' );
 			pcSource++;
-		} while( isdigit( *pcSource ) );
+		} while( isdigit( ( int ) *pcSource ) );
 	}
 
 	*pullAmount = ullAmount;

--- a/plus/Common/Utilities/iperf_task_v3_0f.c
+++ b/plus/Common/Utilities/iperf_task_v3_0f.c
@@ -293,9 +293,8 @@ static void vIPerfTCPClose( TcpClient_t * pxClient )
 	/* Remove server socket from the socket set. */
 	if( pxClient->xServerSocket != NULL )
 	{
-		char pucBuffer[ 16 ];
-
 		#if ( ipconfigUSE_IPv6 == 0 )
+			char pucBuffer[ 16 ];
 			FreeRTOS_inet_ntoa( pxClient->xRemoteAddr.sin_addr, pucBuffer );
 			FreeRTOS_printf( ( "vIPerfTCPClose: Closing server socket %s:%u after %u bytes\n",
 							   pucBuffer,

--- a/plus/Common/Utilities/iperf_task_v3_0f.c
+++ b/plus/Common/Utilities/iperf_task_v3_0f.c
@@ -266,7 +266,7 @@ static void vIPerfServerWork( Socket_t xSocket )
 
 		listSET_LIST_ITEM_OWNER( &( pxClient->xListItem ), ( void * ) pxClient );
 		FreeRTOS_GetRemoteAddress( xNexSocket, ( struct freertos_sockaddr * ) &pxClient->xRemoteAddr );
-		FreeRTOS_inet_ntoa( pxClient->xRemoteAddr.sin_addr, pucBuffer );
+		FreeRTOS_inet_ntoa( pxClient->xRemoteAddr.sin_address.ulIP_IPv4, pucBuffer );
 
 		FreeRTOS_printf( ( "vIPerfTask: Received a connection from %s:%u\n",
 						   pucBuffer,

--- a/plus/Common/Utilities/iperf_task_v3_0f.c
+++ b/plus/Common/Utilities/iperf_task_v3_0f.c
@@ -763,7 +763,7 @@ static void vIPerfTCPWork( TcpClient_t * pxClient )
 									 const struct freertos_sockaddr * pxDest )
 	{
 		( void ) pvData;
-		( void ) pxFrom;
+		( void ) pxDest;
 
 		ulUDPRecvCount += xLength;
 		#if ( ipconfigIPERF_DOES_ECHO_UDP != 0 )


### PR DESCRIPTION
Fixes several warnings in `iperf_task`

* `array subscript has type 'char'` on `isdigit()` invocation
* `unused variable` in `vIPerfTCPClose` in case `ipconfigUSE_IPv6` is set
* `unused variable` in `xOnUdpReceive` in case `ipconfigUSE_CALLBACKS` is set
* added ability to compile without `ipconfigIPv4_BACKWARD_COMPATIBLE` definition