### PR TITLE
iperf_task_3.0g: fix warnings and compilation

### DIFF
--- a/plus/Common/Utilities/iperf_task_v3_0g.c
+++ b/plus/Common/Utilities/iperf_task_v3_0g.c
@@ -1066,7 +1066,7 @@ int sscanf64( char * pcString,
     char * pcSource = pcString;
     uint64_t ullAmount = 0U;
 
-    if( isdigit( *pcSource ) )
+    if( isdigit( (int) *pcSource ) )
     {
         retValue = 1;
 
@@ -1075,7 +1075,7 @@ int sscanf64( char * pcString,
             ullAmount = 10U * ullAmount;
             ullAmount += ( uint64_t ) ( *pcSource - '0' );
             pcSource++;
-        } while( isdigit( *pcSource ) );
+        } while( isdigit( (int) *pcSource ) );
     }
 
     *pullAmount = ullAmount;

--- a/plus/Common/Utilities/iperf_task_v3_0g.c
+++ b/plus/Common/Utilities/iperf_task_v3_0g.c
@@ -812,7 +812,7 @@ static void vIPerfTCPWork( TcpClient_t * pxClient )
                                      const struct freertos_sockaddr * pxDest )
     {
         ( void ) pvData;
-        ( void ) pxFrom;
+        ( void ) pxDest;
 
         ulUDPRecvCount += xLength;
         #if ( ipconfigIPERF_DOES_ECHO_UDP != 0 )

--- a/plus/Common/Utilities/iperf_task_v3_0g.c
+++ b/plus/Common/Utilities/iperf_task_v3_0g.c
@@ -914,6 +914,7 @@ static void vIPerfTCPWork( TcpClient_t * pxClient )
     }
 #endif /* ipconfigIPERF_HAS_UDP */
 
+#if ( ipconfigUSE_IPv6 == 1 )
 static NetworkEndPoint_t * pxFindLocalEndpoint( void )
 {
     NetworkEndPoint_t * pxEndPoint;
@@ -935,6 +936,7 @@ static NetworkEndPoint_t * pxFindLocalEndpoint( void )
 
     return pxEndPoint;
 }
+#endif
 
 void vIPerfTask( void * pvParameter )
 {


### PR DESCRIPTION
* fix error: `implicit declaration of function 'xIPv6_GetIPType'` with `ipconfigUSE_IPv6 == 0`
* fix warning: `array subscript has type 'char'`
* fix warning:  `unused variable` with `ipconfigUSE_CALLBACKS == 1`
