### PR TITLE
iperf_task_3.0g: fix 'strncpy' number of chars

### DIFF
--- a/plus/Common/Utilities/iperf_task_v3_0g.c
+++ b/plus/Common/Utilities/iperf_task_v3_0g.c
@@ -486,7 +486,8 @@ static int vIPerfTCPSend( TcpClient_t * pxClient )
                    if( rc != 0 )
                    {
                        FreeRTOS_printf( ( "Got Control Socket: rc %d: exp: '%s' got: '%s'\n", rc, pcExpectedClient, pcReadBuffer ) );
-                       strncpy( pcExpectedClient, pcReadBuffer, sizeof( pcExpectedClient ) );
+                       strncpy( pcExpectedClient, pcReadBuffer, sizeof( pcExpectedClient ) - 1 );
+                       pcExpectedClient[ sizeof( pcExpectedClient ) - 1 ] = '\0';
                        pxControlClient = pxClient;
                        pxClient->bits.bIsControl = pdTRUE_UNSIGNED;
                        pxClient->eTCP_Status = ( eTCP_Server_Status_t ) ( ( ( int ) pxClient->eTCP_Status ) + 1 );


### PR DESCRIPTION
Fixes the following: 
* `error: 'strncpy' specified bound 80 equals destination size [-Werror=stringop-truncation]` 

(strncpy does not terminate the string, so the number of chars must be lower than size of destination)